### PR TITLE
Make Mocha find test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build/cli.js: $(typings_file) $(wildcard *.ts) $(wildcard tests/*.ts)
 	tsc
 
 test: build/cli.js
-	$(NODE_BIN)/mocha build/tests/
+	$(NODE_BIN)/mocha tests/
 
 clean:
 	rm -rf build


### PR DESCRIPTION
The build is currently failing because Mocha can"t find the tests in build/tests. Tsc outputs the compiled tests into the tests folder. This makes mocha look in the right folder.
