### PR TITLE
Use platform agnostic path seperators

### DIFF
--- a/size_tree.ts
+++ b/size_tree.ts
@@ -1,6 +1,7 @@
 /// <reference path="typings/typings.d.ts" />
 
 import filesize = require('filesize');
+import path = require('path');
 
 import webpack_stats = require('./webpack_stats');
 
@@ -91,12 +92,12 @@ export function dependencySizeTree(stats: webpack_stats.WebpackJsonOutput) {
 		//
 		// root/node_modules/parent/node_modules/child/file/path.js =>
 		//  ['root', 'parent', 'child', 'file/path.js'
-
-		let packages = mod.path.split(/\/node_modules\//);
+		let nodeModulesRegex = new RegExp('\\' + path.sep + 'node_modules' + '\\' + path.sep);
+		let packages = mod.path.split(nodeModulesRegex);
 		let filename = '';
 		if (packages.length > 1) {
 			let lastSegment = packages.pop();
-			let lastPackageName = lastSegment.slice(0, lastSegment.search(/\/|$/));
+			let lastPackageName = lastSegment.slice(0, lastSegment.search(new RegExp('\\' + path.sep + '|$')));
 			packages.push(lastPackageName);
 			filename = lastSegment.slice(lastPackageName.length + 1);
 		} else {

--- a/tests/size_tree_test.ts
+++ b/tests/size_tree_test.ts
@@ -29,7 +29,7 @@ style-loader: 717 B (0.379%)
 });
 
 describe('dependencySizeTree()', () => {
-	it('should produce correct results where loaders are used', () => {
+	function getWebpackOutput(): webpack_stats.WebpackJsonOutput {
 		let webpackOutput: webpack_stats.WebpackJsonOutput = {
 			version: '1.2.3',
 			hash: 'unused',
@@ -44,6 +44,10 @@ describe('dependencySizeTree()', () => {
 				name: './foo.js'
 			}]
 		};
+		return webpackOutput;
+	}
+	it('should produce correct results where loaders are used', () => {
+		let webpackOutput = getWebpackOutput();
 		const depsTree = size_tree.dependencySizeTree(webpackOutput);
 		expect(depsTree).to.deep.equal({
 			packageName: '<root>',
@@ -55,4 +59,22 @@ describe('dependencySizeTree()', () => {
 			}]
 		});
 	});
+	it('should work with Windows style paths as well', () => {
+		let webpackOutput = getWebpackOutput();
+		webpackOutput.modules[0].identifier = '\\path\\to\\loader.js!\\path\\to\\project\\node_modules\\dep\\foo.js';
+		webpackOutput.modules[0].name = '.\\foo.js';
+		
+		const depsTree = size_tree.dependencySizeTree(webpackOutput);
+		expect(depsTree).to.deep.equal({
+			packageName: '<root>',
+			size: 1234,
+			children: [{
+				packageName: 'dep',
+				size: 1234,
+				children: []
+			}]
+		});
+	})
 });
+
+


### PR DESCRIPTION
The script didn't work on Windows(didn't find any packages in modules) because the path seperator in the regexes were hardcoded.

I haven't worked with Typescript before, so i don't know if theres a smarter way to go about this, but you get the general idea.
