### PR TITLE
add --no-share-stats option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-size-analyzer",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A utility to find how your dependencies are contributing to the size of your Webpack bundles",
   "main": "build/size_tree.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bundle-size-analyzer",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A utility to find how your dependencies are contributing to the size of your Webpack bundles",
   "main": "build/size_tree.js",
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,18 +4,19 @@ import fs = require('fs');
 import size_tree = require('./size_tree');
 import webpack_stats = require('./webpack_stats');
 
-function printStats(json: string, outputAsJson: boolean) {
+function printStats(json: string, opts: { outputAsJson: boolean, sharesStat: boolean }) {
     const bundleStats = JSON.parse(json) as webpack_stats.WebpackStats;
 	const depTrees = size_tree.dependencySizeTree(bundleStats);
-    if (outputAsJson) {
+    if (opts.outputAsJson) {
         console.log(JSON.stringify(depTrees, undefined, 2));
     } else {
-        depTrees.forEach(tree => size_tree.printDependencySizeTree(tree));
+        depTrees.forEach(tree => size_tree.printDependencySizeTree(tree, opts.sharesStat));
     }
 }
 
 commander.version('1.1.0')
          .option('-j --json', 'Output as JSON')
+         .option('--no-shares-stat', 'Suppress shares stat from output')
          .usage('[options] [Webpack JSON output]')
          .description(
  `Analyzes the JSON output from 'webpack --json'
@@ -30,14 +31,17 @@ commander.version('1.1.0')
 commander.parse(process.argv);
 
 
-const outputAsJson = commander['json'];
+const opts = {
+	outputAsJson: commander['json'],
+	sharesStat:   commander['sharesStat']
+}
 
 if (commander.args[0]) {
-	printStats(fs.readFileSync(commander.args[0]).toString(), outputAsJson);
+	printStats(fs.readFileSync(commander.args[0]).toString(), opts);
 } else if (!process.stdin.isTTY) {
 	let json = '';
 	process.stdin.on('data', (chunk: any) => json += chunk.toString());
-	process.stdin.on('end', () => printStats(json, outputAsJson));
+	process.stdin.on('end', () => printStats(json, opts));
 } else {
 	console.error('No Webpack JSON output file specified. Use `webpack --json` to generate it.');
 	process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,19 +4,19 @@ import fs = require('fs');
 import size_tree = require('./size_tree');
 import webpack_stats = require('./webpack_stats');
 
-function printStats(json: string, opts: { outputAsJson: boolean, sharesStat: boolean }) {
+function printStats(json: string, opts: { outputAsJson: boolean, shareStats: boolean }) {
     const bundleStats = JSON.parse(json) as webpack_stats.WebpackStats;
 	const depTrees = size_tree.dependencySizeTree(bundleStats);
     if (opts.outputAsJson) {
         console.log(JSON.stringify(depTrees, undefined, 2));
     } else {
-        depTrees.forEach(tree => size_tree.printDependencySizeTree(tree, opts.sharesStat));
+        depTrees.forEach(tree => size_tree.printDependencySizeTree(tree, opts.shareStats));
     }
 }
 
 commander.version('1.1.0')
          .option('-j --json', 'Output as JSON')
-         .option('--no-shares-stat', 'Suppress shares stat from output')
+         .option('--no-share-stats', 'Do not output dependency sizes as a percentage')
          .usage('[options] [Webpack JSON output]')
          .description(
  `Analyzes the JSON output from 'webpack --json'
@@ -33,7 +33,7 @@ commander.parse(process.argv);
 
 const opts = {
 	outputAsJson: commander['json'],
-	sharesStat:   commander['sharesStat']
+	shareStats:   commander['shareStats']
 }
 
 if (commander.args[0]) {

--- a/src/size_tree.ts
+++ b/src/size_tree.ts
@@ -30,7 +30,7 @@ export interface RootStatsNode extends StatsNode {
   * size contributed to the bundle by each package's own code plus those
   * of its dependencies.
   */
-export function printDependencySizeTree(node: StatsNode, sharesStat: boolean, depth: number = 0,
+export function printDependencySizeTree(node: StatsNode, shareStats: boolean, depth: number = 0,
   outputFn: (str: string) => void = console.log) {
 
 	if (node.hasOwnProperty('bundleName')) {
@@ -54,13 +54,13 @@ export function printDependencySizeTree(node: StatsNode, sharesStat: boolean, de
 	for (const child of childrenBySize) {
 		++includedCount;
 		let out = `${prefix}${child.packageName}: ${filesize(child.size)}`;
-		if (sharesStat) {
+		if (shareStats) {
 			const percentage = ((child.size/totalSize) * 100).toPrecision(3);
 			out = `${out} (${percentage}%)`;
 		}
 		outputFn(out);
 	
-		printDependencySizeTree(child, sharesStat, depth + 1, outputFn);
+		printDependencySizeTree(child, shareStats, depth + 1, outputFn);
 
 		remainder -= child.size;
 
@@ -71,7 +71,7 @@ export function printDependencySizeTree(node: StatsNode, sharesStat: boolean, de
 
 	if (depth === 0 || remainder !== totalSize) {
 		let out = `${prefix}<self>: ${filesize(remainder)}`;
-		if (sharesStat) {
+		if (shareStats) {
 			const percentage = ((remainder/totalSize) * 100).toPrecision(3);
 			out = `${out} (${percentage}%)`
 		}

--- a/src/size_tree.ts
+++ b/src/size_tree.ts
@@ -30,7 +30,7 @@ export interface RootStatsNode extends StatsNode {
   * size contributed to the bundle by each package's own code plus those
   * of its dependencies.
   */
-export function printDependencySizeTree(node: StatsNode, depth: number = 0,
+export function printDependencySizeTree(node: StatsNode, sharesStat: boolean, depth: number = 0,
   outputFn: (str: string) => void = console.log) {
 
 	if (node.hasOwnProperty('bundleName')) {
@@ -53,10 +53,14 @@ export function printDependencySizeTree(node: StatsNode, depth: number = 0,
 
 	for (const child of childrenBySize) {
 		++includedCount;
-		const percentage = ((child.size/totalSize) * 100).toPrecision(3);
-		outputFn(`${prefix}${child.packageName}: ${filesize(child.size)} (${percentage}%)`);
+		let out = `${prefix}${child.packageName}: ${filesize(child.size)}`;
+		if (sharesStat) {
+			const percentage = ((child.size/totalSize) * 100).toPrecision(3);
+			out = `${out} (${percentage}%)`;
+		}
+		outputFn(out);
 	
-		printDependencySizeTree(child, depth + 1, outputFn);
+		printDependencySizeTree(child, sharesStat, depth + 1, outputFn);
 
 		remainder -= child.size;
 
@@ -66,8 +70,12 @@ export function printDependencySizeTree(node: StatsNode, depth: number = 0,
 	}
 
 	if (depth === 0 || remainder !== totalSize) {
-		const percentage = ((remainder/totalSize) * 100).toPrecision(3);
-		outputFn(`${prefix}<self>: ${filesize(remainder)} (${percentage}%)`);
+		let out = `${prefix}<self>: ${filesize(remainder)}`;
+		if (sharesStat) {
+			const percentage = ((remainder/totalSize) * 100).toPrecision(3);
+			out = `${out} (${percentage}%)`
+		}
+		outputFn(out);
 	}
 }
 

--- a/tests/size_tree_test.ts
+++ b/tests/size_tree_test.ts
@@ -5,8 +5,8 @@ import path = require('path');
 import size_tree = require('../src/size_tree');
 import webpack_stats = require('../src/webpack_stats');
 
-const printSharesStat    = true;
-const suppressSharesStat = false;
+const printShareStats    = true;
+const suppressShareStats = false;
 
 describe('printDependencySizeTree()', () => {
 	it('should print the size tree', () => {
@@ -24,7 +24,7 @@ describe('printDependencySizeTree()', () => {
 
 		const depsTree = size_tree.dependencySizeTree(statsJson);
 		expect(depsTree.length).to.equal(1);
-		size_tree.printDependencySizeTree(depsTree[0], printSharesStat, 0, line => output += '\n' + line);
+		size_tree.printDependencySizeTree(depsTree[0], printShareStats, 0, line => output += '\n' + line);
 
 		expect(output).to.equal(
 `
@@ -35,7 +35,7 @@ style-loader: 717 B (0.379%)
 );
 	});
 
-	it('should print the size tree without shares stat', () => {
+	it('should print the size tree without share stats', () => {
 		let output = '';
 
 		const statsJsonStr = fs.readFileSync(path.join('tests', 'stats.json')).toString();
@@ -50,7 +50,7 @@ style-loader: 717 B (0.379%)
 
 		const depsTree = size_tree.dependencySizeTree(statsJson);
 		expect(depsTree.length).to.equal(1);
-		size_tree.printDependencySizeTree(depsTree[0], suppressSharesStat, 0, line => output += '\n' + line);
+		size_tree.printDependencySizeTree(depsTree[0], suppressShareStats, 0, line => output += '\n' + line);
 
 		expect(output).to.equal(
 `
@@ -69,14 +69,14 @@ style-loader: 717 B
 			size: 123,
 			children: [],
 		};
-		size_tree.printDependencySizeTree(namedBundle, printSharesStat, 0, line => output += '\n' + line);
+		size_tree.printDependencySizeTree(namedBundle, printShareStats, 0, line => output += '\n' + line);
 		expect(output).to.equal(
 `
 Bundle: a-bundle
 <self>: 123 B (100%)`);
 	});
 
-	it('should print the bundle name without shares stat', () => {
+	it('should print the bundle name without share stats', () => {
 		let output = '';
 		let namedBundle: size_tree.RootStatsNode = {
 			bundleName: 'a-bundle',
@@ -84,7 +84,7 @@ Bundle: a-bundle
 			size: 123,
 			children: [],
 		};
-		size_tree.printDependencySizeTree(namedBundle, suppressSharesStat, 0, line => output += '\n' + line);
+		size_tree.printDependencySizeTree(namedBundle, suppressShareStats, 0, line => output += '\n' + line);
 		expect(output).to.equal(
 `
 Bundle: a-bundle


### PR DESCRIPTION
added option `--no-shares-stat`

I am calculating metrics for each PR, commit it, and see its diff during code review.
Shares stat like `(15.12%)` produces to verbose diffs on any change of code. I'd like to see diff only when actual file size is changed.