### PR TITLE
Include package name for scoped packages

### DIFF
--- a/src/size_tree.ts
+++ b/src/size_tree.ts
@@ -108,7 +108,14 @@ function bundleSizeTree(stats: webpack_stats.WebpackCompilation) {
 		let filename = '';
 		if (packages.length > 1) {
 			let lastSegment = packages.pop() as string;
-			let lastPackageName = lastSegment.slice(0, lastSegment.search(new RegExp('\\' + path.sep + '|$')));
+			let lastPackageName = '';
+			if(lastSegment[0] === ('@')){
+				// package is a scoped package
+				let offset = lastSegment.indexOf(path.sep) + 1;
+				lastPackageName = lastSegment.slice(0, offset + lastSegment.slice(offset).indexOf(path.sep));
+			} else {
+			 	lastPackageName = lastSegment.slice(0, lastSegment.indexOf(path.sep));
+			}
 			packages.push(lastPackageName);
 			filename = lastSegment.slice(lastPackageName.length + 1);
 		} else {

--- a/tests/size_tree_test.ts
+++ b/tests/size_tree_test.ts
@@ -86,4 +86,40 @@ describe('dependencySizeTree()', () => {
 		const depsTree = size_tree.dependencySizeTree(statsJson);
 		expect(depsTree.length).to.equal(2);
 	});
+
+	it('should include the package name of scoped packages', () => {
+		let webpackOutput: webpack_stats.WebpackCompilation = {
+			version: '1.2.3',
+			hash: 'unused',
+			time: 100,
+			assetsByChunkName: {},
+			assets: [],
+			chunks: [],
+			modules: [{
+				id: 0,
+				identifier: path.join('/', 'path', 'to', 'project', 'node_modules', '@scope', 'package1', 'foo.js'),
+				size: 1234,
+				name: path.join('.', 'foo.js')
+			}, {
+				id: 0,
+				identifier: path.join('/', 'path', 'to', 'project', 'node_modules', '@scope', 'package2', 'bar.js'),
+				size: 1234,
+				name: path.join('.', 'bar.js')
+			}],
+			errors: [],
+			warnings: [],
+		};
+		const depsTree = size_tree.dependencySizeTree(webpackOutput);
+		expect(depsTree.length).to.equal(1);
+		expect(depsTree[0].children).to.deep.include({
+			packageName: '@scope/package1',
+			size: 1234,
+			children: []
+		});
+		expect(depsTree[0].children).to.deep.include({
+			packageName: '@scope/package2',
+			size: 1234,
+			children: []
+		});
+	});
 });


### PR DESCRIPTION
This PR fixes #25 by including the package name in addition to the scope name (instead of 'angular' the package name would for example be 'angular/core'). This PR doesn't create fake packages representing the scope, since the scope is only a logical grouping of packages and doesn't really imply a dependency.