### PR TITLE
Add a note about misleading file sizes to the CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,10 @@ The parsing error was:
       console.log(JSON.stringify(depTrees, undefined, 2));
   } else {
       depTrees.forEach(tree => size_tree.printDependencySizeTree(tree, opts.shareStats));
+      console.log(
+        'Note: the file sizes are calculated before minification, ' +
+	'and might not reflect the real file sizes in the production bundle.'
+      );
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ The parsing error was:
       depTrees.forEach(tree => size_tree.printDependencySizeTree(tree, opts.shareStats));
       console.log(
         'Note: the file sizes are calculated before minification, ' +
-	'and might not reflect the real file sizes in the production bundle.'
+        'and might not reflect the real file sizes in the production bundle.'
       );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/robertknight/webpack-bundle-size-analyzer/issues/40.
I typed this in the GitHub editor, so I have not really tested it.

Thanks for consideration!